### PR TITLE
Fixed creative hand, made skybox optional

### DIFF
--- a/mods/ws_core/skybox.lua
+++ b/mods/ws_core/skybox.lua
@@ -12,26 +12,28 @@ local moon_tint = "#96A6FF"
 local cloud_color = "#FFDAAA"
 local star_color = "#FFDAAA"
 
-minetest.register_on_joinplayer(function(player)
-	player:set_sky({
-	type = "regular",
-	clouds = true,
-	sky_color = {
-		day_sky = day_sky,
-		day_horizon = day_horizon,
-		dawn_sky = dawn_sky,
-		night_sky = night_sky,
-		night_horizon = night_horizon,
-	}
-})
+if minetest.settings:get_bool("ws_enable_skybox", true) then
+	minetest.register_on_joinplayer(function(player)
+		player:set_sky({
+			type = "regular",
+			clouds = true,
+			sky_color = {
+				day_sky = day_sky,
+				day_horizon = day_horizon,
+				dawn_sky = dawn_sky,
+				night_sky = night_sky,
+				night_horizon = night_horizon,
+			}
+		})
 
-player:set_clouds({
-	color = cloud_color
-})
+		player:set_clouds({
+			color = cloud_color
+		})
 
-player:set_stars({
-	count = 3000,
-	star_color = star_color,
-	scale = 0.8
-})
-end)
+		player:set_stars({
+			count = 3000,
+			star_color = star_color,
+			scale = 0.8
+		})
+	end)
+end

--- a/mods/ws_core/tools.lua
+++ b/mods/ws_core/tools.lua
@@ -1,18 +1,20 @@
-minetest.register_item(":", {
-	type = "none",
-	wield_image = "wieldhand.png",
-	wield_scale = {x=1,y=1,z=2.5},
-	tool_capabilities = {
-		full_punch_interval = 0.9,
-		max_drop_level = 0,
-		groupcaps = {
-			crumbly = {times={[2]=3.00, [3]=0.70}, uses=0, maxlevel=1},
-			snappy = {times={[3]=0.40}, uses=0, maxlevel=1},
-			oddly_breakable_by_hand = {times={[1]=3.50,[2]=2.00,[3]=0.70}, uses=0}
-		},
-		damage_groups = {fleshy=1},
-	}
-})
+if not minetest.settings:get_bool("creative_mode") then
+	minetest.register_item(":", {
+		type = "none",
+		wield_image = "wieldhand.png",
+		wield_scale = {x=1,y=1,z=2.5},
+		tool_capabilities = {
+			full_punch_interval = 0.9,
+			max_drop_level = 0,
+			groupcaps = {
+				crumbly = {times={[2]=3.00, [3]=0.70}, uses=0, maxlevel=1},
+				snappy = {times={[3]=0.40}, uses=0, maxlevel=1},
+				oddly_breakable_by_hand = {times={[1]=3.50,[2]=2.00,[3]=0.70}, uses=0}
+			},
+			damage_groups = {fleshy=1},
+		}
+	})
+end
 
 minetest.register_tool("ws_core:knife_flint", {
 	description = "Flint Knife",

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,0 +1,2 @@
+# This option enables custom skybox for Wastelands Survival game. Minetest 5.2 is required.
+ws_enable_skybox (Enable Custom Skybox) bool true


### PR DESCRIPTION
Creative hand now can break any block fast enough and you don't get drops when you break nodes. This is mostly a change on NEI's side.

Skybox now is enabled in MT Settings, setting is named `ws_enable_skybox`. By default it's enabled.

EDIT: Note that it doesnt address plank issues.